### PR TITLE
fix(recorder): escape single quotes in path of default output (#2137)

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -110,6 +110,10 @@ function generateRequestAndResponse({
     const queryStr = req.path.slice(queryIndex + 1)
     queryObj = querystring.parse(queryStr)
   }
+
+  // Escape any single quotes in the path as the output uses them
+  path = path.replace(/'/g, `\\'`)
+
   // Always encode the query parameters when recording.
   const encodedQueryObj = {}
   for (const key in queryObj) {


### PR DESCRIPTION
Because the default output of the recorder uses single quotes, any such
quotes in the path would generate invalid Javascript.